### PR TITLE
Added description for pre-stable public API versioning

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -67,8 +67,15 @@ Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
 1. Once a versioned package has been released, the contents of that version
 MUST NOT be modified. Any modifications MUST be released as a new version.
 
-1. Major version zero (0.y.z) is for initial development. Anything may change
-at any time. The public API should not be considered stable.
+1. Major version zero (0.y.z) is for initial development. The public API should not be considered stable.
+
+1. Major version zero's minor version (0.Y.z) MUST be incremented if any backwards
+incompatible changes are introduced to the public API. Patch version MUST be reset to 0 when minor
+version is incremented.
+
+1. Major version zero's patch version (0.y.Z) MUST be incremented if new, backwards
+compatible functionality is introduced to the public API or backwards
+compatible bug fixes are introduced to the public API.
 
 1. Version 1.0.0 defines the public API. The way in which the version number
 is incremented after this release is dependent on this public API and how it

--- a/semver.md
+++ b/semver.md
@@ -171,11 +171,6 @@ them.
 FAQ
 ---
 
-### How should I deal with revisions in the 0.y.z initial development phase?
-
-The simplest thing to do is start your initial development release at 0.1.0
-and then increment the minor version for each subsequent release.
-
 ### How do I know when to release 1.0.0?
 
 If your software is being used in production, it should probably already be


### PR DESCRIPTION
When reading the description for major version zero I came across the line "Anything may change 
at any time." I would like to create a more clear explanation of how versioning should take place before the first stable version of the public API so that developers can have meaning behind their pre-stable versioning.

This is especially an issue in node.js development as by default saved modules will pick up new patch versions but not new minor versions. If developers don't properly version their modules in a pre-stable state they can potentially break when users pick up new patch versions.

To define this pre-stable state I have proposed moving the definition for major and minor changes to the right, meaning that API-breaking changes result in a minor version being incremented and both backwards-compatible functional additions as well as bug fixes result in a patch version being incremented.
