### PR TITLE
Include Maven SNAPSHOT pre-release example

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -100,7 +100,7 @@ precedence than the associated normal version. A pre-release version
 indicates that the version is unstable and might not satisfy the
 intended compatibility requirements as denoted by its associated
 normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
-1.0.0-x.7.z.92.
+1.0.0-x.7.z.92, 1.0.0-SNAPSHOT.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot
 separated identifiers immediately following the patch or pre-release version.


### PR DESCRIPTION
The Maven build system uses the keyword "SNAPSHOT" to indicate pre-release builds. Their definition and use fits nicely with the semver pre-release definition so it would be useful to be shown here as an example. Worth mentioning is that the "SNAPSHOT" naming convention is sometimes used by non-Maven projects too.

"you will often see the SNAPSHOT designator in a version, which indicates that a project is in a state of development"
http://maven.apache.org/guides/getting-started
