### PR TITLE
Reverted to published language RE build metadata

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -95,7 +95,8 @@ version is incremented.
 series of dot separated identifiers immediately following the patch
 version. Identifiers MUST comprise only ASCII alphanumerics and hyphen
 [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric identifiers MUST
-NOT include leading zeroes. Pre-release versions have a lower
+NOT include leading zeroes. Alphabetic identifiers MUST include at least
+one non-numeric character. Pre-release versions have a lower
 precedence than the associated normal version. A pre-release version
 indicates that the version is unstable and might not satisfy the
 intended compatibility requirements as denoted by its associated

--- a/semver.md
+++ b/semver.md
@@ -105,7 +105,7 @@ normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot
 separated identifiers immediately following the patch or pre-release version.
 Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
-Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining
+Identifiers MUST NOT be empty. Build metadata SHOULD be ignored when determining
 version precedence. Thus two versions that differ only in the build metadata,
 have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
 1.0.0-beta+exp.sha.5114f85.


### PR DESCRIPTION
"Build metadata SHOULD be ignored" instead of "Build metadata MUST be
ignored".
