### PR TITLE
Changed MUST to MAY for resetting Minor and Patch when incrementing Majo...

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -88,7 +88,7 @@ MUST be reset to 0 when minor version is incremented.
 
 1. Major version X (X.y.z | X > 0) MUST be incremented if any backwards
 incompatible changes are introduced to the public API. It MAY also include minor
-and patch level changes. Patch and minor version MUST be reset to 0 when major
+and patch level changes. Patch and minor version MAY be reset to 0 when major
 version is incremented.
 
 1. A pre-release version MAY be denoted by appending a hyphen and a


### PR DESCRIPTION
There is no need to reset the Minor version number when incrementing the Major, as the new Major version may include the same functionality as the previous Major version.

Patch version numbers need only be reset when the functionality changes. I.e. when the Minor Version is incremented.

Resetting the Minor version to Zero looses the Minor Version Number's helpfulness in seeing at-a-glance how many new feature versions have been developed.

This makes the following legal:

```
1.2.3 -> 2.2.3     // A compatibility-breaking change was introduced, but no patches or new functionality
1.2.3 -> 2.2.4     // A compatibility-breaking patch was introduced, but no new functionality
1.2.3 -> 2.3.0     // A compatibility-breaking feature was introduced
1.2.3 -> 2.0.0     // Any of the above combinations, but you can still reset both if you like!
```
