### PR TITLE
Slightly clarify the build metadata section

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -91,9 +91,11 @@ incompatible changes are introduced to the public API. It MAY also include minor
 and patch level changes. Patch and minor version MUST be reset to 0 when major
 version is incremented.
 
-1. A pre-release version MAY be denoted by appending a hyphen and a
-series of dot separated identifiers immediately following the patch
-version. Identifiers MUST comprise only ASCII alphanumerics and hyphens
+1. A pre-release version MAY be denoted by appending a hyphen followed
+by one or more identifiers. The hyphen immediately follows the patch
+version and is followed by the first identifier. If multiple identifiers
+are used, they are separated with dots.
+Identifiers MUST comprise only ASCII alphanumerics and hyphens
 [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric identifiers MUST
 NOT include leading zeroes. Pre-release versions have a lower
 precedence than the associated normal version. A pre-release version

--- a/semver.md
+++ b/semver.md
@@ -102,8 +102,10 @@ intended compatibility requirements as denoted by its associated
 normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
 1.0.0-x.7.z.92, 1.0.0-x-y-z.--.
 
-1. Build metadata MAY be denoted by appending a plus sign and a series of dot
-separated identifiers immediately following the patch or pre-release version.
+1. Build metadata MAY be denoted by appending a plus sign followed by one
+or more identifiers. The plus sign immediately follows the patch or
+pre-release version and is followed by the first identifier. If multiple
+identifiers are used, they are separated with dots.
 Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-].
 Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining
 version precedence. Thus two versions that differ only in the build metadata,


### PR DESCRIPTION
Multiple people (#291, #249, #230, #293) have missed the fact that the
build metadata can contain multiple _dot-separated_ identifers, and were
confused enough to report a bug about the dots present in one of the
examples. This attempts to make it more obvious that multiple
identifiers might be used.

This closes #293.
