### PR TITLE
Stylise "backwards compatible" consistently

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -7,9 +7,9 @@ Summary
 Given a version number MAJOR.MINOR.PATCH, increment the:
 
 1. MAJOR version when you make incompatible API changes,
-1. MINOR version when you add functionality in a backwards-compatible
+1. MINOR version when you add functionality in a backwards compatible
    manner, and
-1. PATCH version when you make backwards-compatible bug fixes.
+1. PATCH version when you make backwards compatible bug fixes.
 
 Additional labels for pre-release and build metadata are available as extensions
 to the MAJOR.MINOR.PATCH format.


### PR DESCRIPTION
Later in the document, it's consistently spelt with a space, rather than a hyphen - so I figure it should be here, too.