### PR TITLE
Clarify if change is breaking for a specific platform only

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -6,7 +6,7 @@ Summary
 
 Given a version number MAJOR.MINOR.PATCH, increment the:
 
-1. MAJOR version when you make incompatible API changes,
+1. MAJOR version when you make incompatible changes,
 1. MINOR version when you add functionality in a backwards-compatible
    manner, and
 1. PATCH version when you make backwards-compatible bug fixes.

--- a/semver.md
+++ b/semver.md
@@ -87,9 +87,11 @@ within the private code. It MAY include patch level changes. Patch version
 MUST be reset to 0 when minor version is incremented.
 
 1. Major version X (X.y.z | X > 0) MUST be incremented if any backwards
-incompatible changes are introduced to the public API. It MAY also include minor
-and patch level changes. Patch and minor version MUST be reset to 0 when major
-version is incremented.
+incompatible changes are introduced to the public API. Major version MUST also
+be incremented if the software can no longer run on any of the
+platforms or frameworks it used to run on, even if API stayed the same. 
+It MAY also include minor and patch level changes. 
+Patch and minor version MUST be reset to 0 when major version is incremented.
 
 1. A pre-release version MAY be denoted by appending a hyphen and a
 series of dot separated identifiers immediately following the patch


### PR DESCRIPTION
As discussed in #444 with @jwdonahue, I'm supplying a PR which clearly states that even if API does not change but a software update breaks something then it should be a MAJOR release.

Closes #444

Probably this is not the best wording ever, and maybe even contradicts something else, but I took a careful look over the the whole specification. I believe this change is compatible with everything else in the specification.

If anything should be reworked - reworded - removed - rethought - etc, I'm happy to continue.