### PR TITLE
Add "package or API" in MAJOR version description

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -6,7 +6,7 @@ Summary
 
 Given a version number MAJOR.MINOR.PATCH, increment the:
 
-1. MAJOR version when you make incompatible API changes,
+1. MAJOR version when you make incompatible package or API changes,
 1. MINOR version when you add functionality in a backwards compatible
    manner, and
 1. PATCH version when you make backwards compatible bug fixes.


### PR DESCRIPTION
As discussed in #444 with @jwdonahue, I'm supplying a PR which clearly states that even if API does not change but a software update breaks something then it should be a MAJOR release.

Closes #444

Previous attempt: #452