### PR TITLE
Clarify minor and patch versions

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -7,7 +7,7 @@ Summary
 Given a version number MAJOR.MINOR.PATCH, increment the:
 
 1. MAJOR version when you make incompatible API changes,
-1. MINOR version when you add functionality in a backwards compatible
+1. MINOR version when you add functionality to the API in a backwards compatible
    manner, and
 1. PATCH version when you make backwards compatible bug fixes.
 

--- a/semver.md
+++ b/semver.md
@@ -9,7 +9,8 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 1. MAJOR version when you make incompatible API changes,
 1. MINOR version when you add functionality to the API in a backwards compatible
    manner, and
-1. PATCH version when you make backwards compatible bug fixes.
+1. PATCH version when you make backwards compatible bug fixes or other changes
+   not affecting the API.
 
 Additional labels for pre-release and build metadata are available as extensions
 to the MAJOR.MINOR.PATCH format.
@@ -39,10 +40,10 @@ For this system to work, you first need to declare a public API. This may
 consist of documentation or be enforced by the code itself. Regardless, it is
 important that this API be clear and precise. Once you identify your public
 API, you communicate changes to it with specific increments to your version
-number. Consider a version format of X.Y.Z (Major.Minor.Patch). Bug fixes not
-affecting the API increment the patch version, backwards compatible API
-additions/changes increment the minor version, and backwards incompatible API
-changes increment the major version.
+number. Consider a version format of X.Y.Z (Major.Minor.Patch). Bug fixes or
+other changes not affecting the API increment the patch version, backwards
+compatible API additions/changes increment the minor version, and backwards
+incompatible API changes increment the major version.
 
 I call this system "Semantic Versioning." Under this scheme, version numbers
 and the way they change convey meaning about the underlying code and what has
@@ -75,8 +76,8 @@ is incremented after this release is dependent on this public API and how it
 changes.
 
 1. Patch version Z (x.y.Z | x > 0) MUST be incremented if only backwards
-compatible bug fixes are introduced. A bug fix is defined as an internal
-change that fixes incorrect behavior.
+compatible bug fixes or other changes not affecting the API are introduced. A
+bug fix is defined as an internal change that fixes incorrect behavior.
 
 1. Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards
 compatible functionality is introduced to the public API. It MUST be


### PR DESCRIPTION
This is not a "substantial" change to the specification, hence not an RFC. It just clarifies aspects in MINOR and PATCH version that is not clear when reading the changed sections separately. However, when reading the whole document, it becomes clear that the new wording is the intention.

This change is an attempt to minimize the changes needed to add these clarifications while still keeping the text as short and concise as possible. With a larger change, it would be possible to make the text even shorter by removing the references to *bug fixes*. Let me know if prefer this and I can change this PR accordingly.

Here are some references to issues opened in the past because of the currently somewhat ambigous formulation:

* https://github.com/semver/semver/issues/560
* https://github.com/semver/semver/issues/313
* https://github.com/semver/semver/issues/339
* https://github.com/semver/semver/issues/148
* https://github.com/semver/semver/issues/146
