### PR TITLE
Changed `positive digit` to `non-zero digit`as per issue #665

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -182,8 +182,8 @@ Backus–Naur Form Grammar for Valid SemVer Versions
                             | <identifier characters> <non-digit> <identifier characters>
 
 <numeric identifier> ::= "0"
-                       | <positive digit>
-                       | <positive digit> <digits>
+                       | <non-zero digit>
+                       | <non-zero digit> <digits>
 
 <identifier characters> ::= <identifier character>
                           | <identifier character> <identifier characters>
@@ -198,9 +198,9 @@ Backus–Naur Form Grammar for Valid SemVer Versions
            | <digit> <digits>
 
 <digit> ::= "0"
-          | <positive digit>
+          | <non-zero digit>
 
-<positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+<non-zero digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 
 <letter> ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J"
            | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T"

--- a/semver.md
+++ b/semver.md
@@ -1,4 +1,4 @@
-Semantic Versioning 2.0.0
+Semantic Versioning 2.0.1
 ==============================
 
 Summary


### PR DESCRIPTION
Note:

- I have not upgrade the version at the top of the page, still at 2.0.0. Technically, should become 2.0.1 I suppose.
- I have used the name `non-zero digit` rather than `nonzero digit` similar to the existing `non-digit`.It's a matter of taste.

Fixes https://github.com/semver/semver/issues/665