### PR TITLE
RFC proposal for semver 3.0.0 - LIBRARY version

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -1,18 +1,19 @@
-Semantic Versioning 2.0.0
+Semantic Versioning 3.0.0
 ==============================
 
 Summary
 -------
 
-Given a version number MAJOR.MINOR.PATCH, increment the:
+Given a version number LIBRARY.MAJOR.MINOR.PATCH, increment the:
 
+1. LIBRARY version when you make incompatible architectural changes,
 1. MAJOR version when you make incompatible API changes,
 1. MINOR version when you add functionality in a backwards compatible
    manner, and
 1. PATCH version when you make backwards compatible bug fixes.
 
 Additional labels for pre-release and build metadata are available as extensions
-to the MAJOR.MINOR.PATCH format.
+to the LIBRARY.MAJOR.MINOR.PATCH format.
 
 Introduction
 ------------
@@ -74,20 +75,25 @@ at any time. The public API SHOULD NOT be considered stable.
 is incremented after this release is dependent on this public API and how it
 changes.
 
-1. Patch version Z (x.y.Z | x > 0) MUST be incremented if only backwards
+1. Patch version Z (w.x.y.Z | w & x > 0) MUST be incremented if only backwards
 compatible bug fixes are introduced. A bug fix is defined as an internal
 change that fixes incorrect behavior.
 
-1. Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards
+1. Minor version Y (w.x.Y.z | w & x > 0) MUST be incremented if new, backwards
 compatible functionality is introduced to the public API. It MUST be
 incremented if any public API functionality is marked as deprecated. It MAY be
 incremented if substantial new functionality or improvements are introduced
 within the private code. It MAY include patch level changes. Patch version
 MUST be reset to 0 when minor version is incremented.
 
-1. Major version X (X.y.z | X > 0) MUST be incremented if any backwards
+1. Major version X (w.X.y.z | w & X > 0) MUST be incremented if any backwards
 incompatible changes are introduced to the public API. It MAY also include minor
 and patch level changes. Patch and minor version MUST be reset to 0 when major
+version is incremented.
+
+1. Library version W (W.x.y.z | W > 0) MUST be incremented if any
+incompatible architectural changes are introduced to the public API. It MAY also include major, minor
+and patch level changes. Major, patch and minor version MUST be reset to 0 when library
 version is incremented.
 
 1. A pre-release version MAY be denoted by appending a hyphen and a
@@ -119,14 +125,14 @@ have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
       these identifiers from left to right as follows: Major, minor, and patch
       versions are always compared numerically.
 
-      Example: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1.
+      Example: 1.0.0.0 < 2.0.0.0 < 2.1.0.0 < 2.1.1.0
 
-   1. When major, minor, and patch are equal, a pre-release version has lower
+   1. When library, major, minor, and patch are equal, a pre-release version has lower
       precedence than a normal version:
 
-      Example: 1.0.0-alpha < 1.0.0.
+      Example: 1.0.0.0-alpha < 1.0.0.0.
 
-   1. Precedence for two pre-release versions with the same major, minor, and
+   1. Precedence for two pre-release versions with the same library, major, minor, and
       patch version MUST be determined by comparing each dot separated identifier
       from left to right until a difference is found as follows:
 
@@ -152,7 +158,9 @@ Backus–Naur Form Grammar for Valid SemVer Versions
                  | <version core> "+" <build>
                  | <version core> "-" <pre-release> "+" <build>
 
-<version core> ::= <major> "." <minor> "." <patch>
+<version core> ::= <library> "." <major> "." <minor> "." <patch>
+
+<library> ::= <numeric identifier>
 
 <major> ::= <numeric identifier>
 
@@ -251,27 +259,31 @@ FAQ
 The simplest thing to do is start your initial development release at 0.1.0
 and then increment the minor version for each subsequent release.
 
-### How do I know when to release 1.0.0?
+### How do I know when to release 1.0.0.0?
 
 If your software is being used in production, it should probably already be
-1.0.0. If you have a stable API on which users have come to depend, you should
-be 1.0.0. If you're worrying a lot about backwards compatibility, you should
-probably already be 1.0.0.
+1.0.0.0. If you have a stable API on which users have come to depend, you should
+be 1.0.0.0. If you're worrying a lot about backwards compatibility, you should
+probably already be 1.0.0.0.
 
 ### Doesn't this discourage rapid development and fast iteration?
 
 Major version zero is all about rapid development. If you're changing the API
-every day you should either still be in version 0.y.z or on a separate
+every day you should either still be in version 0.0.y.z or on a separate
 development branch working on the next major version.
 
-### If even the tiniest backwards incompatible changes to the public API require a major version bump, won't I end up at version 42.0.0 very rapidly?
+### How do I version my library?
 
-This is a question of responsible development and foresight. Incompatible
-changes should not be introduced lightly to software that has a lot of
-dependent code. The cost that must be incurred to upgrade can be significant.
-Having to bump major versions to release incompatible changes means you'll
-think through the impact of your changes, and evaluate the cost/benefit ratio
-involved.
+Your library as a whole has a given approach and architecture. You might start out 
+releasing the first public version of your library as 1.0.0.0.  When you make significant 
+architectural changes to your library, you'll need to bump the library version, e.g. 2.0.0.0.
+This signals developers that 1.x follows the same architecture, 1.1.x is architecturally compatible 
+with 1.x, but backwards incompatible with 1.0.0.
+
+For example, a developer might pessimistically version a rubygem as '\~> 5.2.0', meaning:
+give me only non-breaking changes in library version 5, major version 2 lineage. This solves the 
+dilemma where Rails 5.2.x introduces a breaking change, yet, Rails 6.x indicates a major difference in 
+architecture.
 
 ### Documenting the entire public API is too much work!
 


### PR DESCRIPTION
While looking at Rails versioning, I notice that some PATCH level changes have breaking changes now. For example:

* [Update Changelog entry for 5.2.4.1 to warn of breaking changes](https://github.com/rails/rails/commit/c1ca9c7b365cdac9ccd8eb1716173ea3aef89892)

SemVer 2.0 says:

> 8. Major version X (X.y.z | X > 0) MUST be incremented if any backwards incompatible changes are introduced to the public API

If Rails followed this advice, then the logical semver increment from 5.2.4 would have to be 6.x, not 5.2.4.1.  But Rails 6.x already means something bigger than an incompatible API change -- it means a group of incompatible architectural changes with the previous version.

Indeed, many gems in the ecosystem face this dilemma.

## Proposal: LIBRARY version

Given a version number LIBRARY.MAJOR.MINOR.PATCH, increment the:

    LIBRARY version when you make incompatible architectural changes.
    MAJOR version when you make incompatible API changes,
    MINOR version when you add functionality in a backwards compatible manner, and
    PATCH version when you make backwards compatible bug fixes.

So, for the above example, the bump could have been: 5.3.0.0
