### PR TITLE
docs: add a regex compatible with Bash

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -336,7 +336,7 @@ name and the semantic version is "1.2.3".
 
 ### Is there a suggested regular expression (RegEx) to check a SemVer string?
 
-There are two. One with named groups for those systems that support them
+There are three. One with named groups for those systems that support them
 (PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and R], Python
 and Go).
 
@@ -346,7 +346,7 @@ See: <https://regex101.com/r/Ly7O1x/3/>
 ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 ```
 
-And one with numbered capture groups instead (so cg1 = major, cg2 = minor,
+One with numbered capture groups instead (so cg1 = major, cg2 = minor,
 cg3 = patch, cg4 = prerelease and cg5 = buildmetadata) that is compatible
 with ECMA Script (JavaScript), PCRE (Perl Compatible Regular Expressions,
 i.e. Perl, PHP and R), Python and Go.
@@ -355,6 +355,12 @@ See: <https://regex101.com/r/vkijKf/1/>
 
 ```
 ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+One that is compatible with Bash:
+
+```
+^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$
 ```
 
 About


### PR DESCRIPTION
`\d` and capture groups aren't compatible with Bash. I added a compatible regex. I hope it will help.