### PR TITLE
Remove shall and shall not from the note

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -51,9 +51,9 @@ been modified from one version to the next.
 Semantic Versioning Specification (SemVer)
 ------------------------------------------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT"
+, "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted 
+as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 1. Software using Semantic Versioning MUST declare a public API. This API
 could be declared in the code itself or exist strictly in documentation.


### PR DESCRIPTION
The document does NOT use the words "SHALL" or "SHALL NOT" so let's not include them in this clarification.