### PR TITLE
Escape dashes in the `1.0.0+21AF26D3----117B344092BD` example.

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -107,7 +107,7 @@ Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-].
 Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining
 version precedence. Thus two versions that differ only in the build metadata,
 have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
-1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3----117B344092BD.
+1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3\-\-\-\-117B344092BD.
 
 1. Precedence refers to how versions are compared to each other when ordered.
 


### PR DESCRIPTION
When unescaped, the first three dashes are rendered as an em dash at https://semver.org/#spec-item-10

> ... 1.0.0+21AF26D3—-117B344092BD.

Adding the backspaces should prevent this issue.