### PR TITLE
docs: create CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you reference the Semantic Versioning Specification in your work, please use this metadata."
+abstract: '"Semantic Versioning" or "SemVer" contain a set of rules and requirements that dictate how version numbers are assigned and incremented.'
+authors:
+  - family-names: Preston-Werner
+    given-names: Tom
+title: Semantic Versioning Specification
+version: 2.0.0
+date-released: 2013-06-18
+url: "https://semver.org"
+repository-code: "https://github.com/semver/semver"
+license: "CC-BY-3.0"


### PR DESCRIPTION
Hello! 👋

I'm a university student and recently composed a written report & presentation that directly referenced the Semantic Versioning Specification. As is customary in academia, I was expected to cite my sources in a way that conformed with a particular  English formatting and style guide. I looked through both https://github.com/semver/semver and https://github.com/semver/semver.org, but could find no written documentation indicating how to properly cite the SemVer spec in my paper. The closest I came was to discovering issue #357 from 2017, which references a Google Scholar link that has since been removed. 

GitHub directly supports repository [citation files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) that conform to the [Citation File Format](https://citation-file-format.github.io/) standard. Adding a `CITATION.cff` file to the root of a repository will cause a "Cite this repository" link to appear under the repo description:
![repo sidebar](https://user-images.githubusercontent.com/35435704/208269638-bcc02a6e-f26f-49a1-a4df-1cd49deb3a0e.png)

Clicking on the text will render a dropdown with a brief message about repository citations, and different formatting options that the viewer can use to cite the repo:
![cite this repository dropdown](https://user-images.githubusercontent.com/35435704/208269578-81f49840-16cc-423d-96f4-573b2bac0018.png)


My PR creates a `CITATION.cff` with information about the original SemVer author, along with the recorded release date of v2.0.0 (according to https://github.com/semver/semver/releases/tag/v2.0.0). Please let me know if any changes should be made to the citation metadata, such as the addition of other authors.