### PR TITLE
semver: Update FAQ entry on regular expressions

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -336,7 +336,7 @@ name and the semantic version is "1.2.3".
 
 ### Is there a suggested regular expression (RegEx) to check a SemVer string?
 
-There are two. One with named groups for those systems that support them
+There are three. One with named groups for those systems that support them
 (PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and R], Python
 and Go).
 
@@ -346,7 +346,7 @@ See: <https://regex101.com/r/Ly7O1x/3/>
 ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 ```
 
-And one with numbered capture groups instead (so cg1 = major, cg2 = minor,
+One with numbered capture groups instead (so cg1 = major, cg2 = minor,
 cg3 = patch, cg4 = prerelease and cg5 = buildmetadata) that is compatible
 with ECMA Script (JavaScript), PCRE (Perl Compatible Regular Expressions,
 i.e. Perl, PHP and R), Python and Go.
@@ -355,6 +355,16 @@ See: <https://regex101.com/r/vkijKf/1/>
 
 ```
 ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+One when non-capturing groups (beginning with `(?:`) aren't available (i.e. in
+POSIX regex), which gives slightly different capture groups (cg1 = major, cg2 =
+minor, cg3 = patch, cg5 = prerelease and cg10 = buildmetadata).
+
+See: <https://regex101.com/r/7XA2jr/1>
+
+```
+^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$
 ```
 
 About


### PR DESCRIPTION
with a third variant that works without non-capturing groups and is compatible with POSIX regex (i.e. for use in bash). This originates from an issue I opened earlier, found here: https://github.com/semver/semver/issues/981

There is a [small repo][2] which contains the terse form of the regex along with a more human-readable one and a bash script that demonstrates and runs the regex against the [set of test strings from regex101][1]. I also went and [created a snippet for this regex on regex101][4].

I only just noticed that there is a [long-standing open PR][3] which adds exactly the same regex (but with less explanation) to the FAQ.


[1]: https://regex101.com/r/vkijKf/1/
[2]: https://github.com/har7an/bash-semver-regex
[3]: https://github.com/semver/semver/pull/724
[4]: https://regex101.com/r/7XA2jr/1